### PR TITLE
Implement basic Composer targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+# Ensure that dependencies are installed before attempting to build a Docker image.
+DOCKER_BUILD_REQ += composer.json vendor
+
+# prepare --- Perform tasks that need to be executed before committing. Stacks
+# with the "prepare" target form the common makefile.
+.PHONY: prepare
+prepare:: artifacts/composer/validate.out
+
+################################################################################
+
+vendor: composer.lock
+	composer install
+
+composer.lock: composer.json
+	composer install
+
+composer.json:
+	composer init --no-interaction
+
+artifacts/composer/validate.out: composer.json
+	@mkdir -p "$(@D)"
+	composer validate --no-check-publish | tee "$@

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,4 @@
 # Ensure that dependencies are installed before attempting to build a Docker image.
-DOCKER_BUILD_REQ += composer.json vendor
+DOCKER_BUILD_REQ += vendor
 
-# prepare --- Perform tasks that need to be executed before committing. Stacks
-# with the "prepare" target form the common makefile.
-.PHONY: prepare
-prepare:: artifacts/composer/validate.out
-
-################################################################################
-
-vendor: composer.lock
-	composer install
-
-composer.lock: composer.json
-	composer install
-
-composer.json:
-	composer init --no-interaction
-
-artifacts/composer/validate.out: composer.json
-	@mkdir -p "$(@D)"
-	composer validate --no-check-publish | tee "$@
+-include .makefiles/pkg/php/v1/composer.mk

--- a/composer.mk
+++ b/composer.mk
@@ -1,0 +1,24 @@
+# Ensure that dependencies are installed before attempting to build a Docker image.
+DOCKER_BUILD_REQ += composer.json composer.lock
+
+# prepare --- Perform tasks that need to be executed before committing. Stacks
+# with the "prepare" target form the common makefile.
+.PHONY: prepare
+prepare:: artifacts/composer/validate.touch
+
+################################################################################
+
+vendor: composer.lock
+	composer install
+
+composer.lock: | composer.json
+	composer install
+
+composer.json:
+	composer init --no-interaction
+
+artifacts/composer/validate.touch: composer.json
+	composer validate --no-check-publish
+
+	@mkdir -p "$(@D)"
+	@touch "$@"


### PR DESCRIPTION
Gotta start somewhere, right?

There's a ton of stuff to get your input on:

- Should it be `pkg-composer` or `pkg-php`? I went with the former, because I know that when I tackle JS, NPM vs Yarn will be a real thing I have to contend with. I also wasn't sure whether multiple "primary" Makefiles in a single `pkg-` repo is possible or advisable.
- I avoided the use of `composer update`. The intent is that this makefile should create a lockfile for you if none exists, but it shouldn't unexpectedly update dependencies for you. This is something that I learned from a similar Makefile for JS/Yarn. I found that I prefer to manage dependency updates explicitly outside of make targets, and it was more annoying when make "spookily" updated things for you.
- I couldn't find any prior art for an explicit `lint` target, or for the technique of using `tee` to produce command output logs as artifacts.
- There was a lot more complexity in some of the makefiles I was sourcing these targets from. They covered things like:
  - Installing Composer from source when not found in PATH
  - Auth credential management, including copying stuff from your home directory into `artifacts`, and setting `COMPOSER_HOME`. I think this was to facilitate doing `composer install` as a Docker build stage in a multi-stage build, when there are private Composer repositories involved.
- Some [`composer install`](https://getcomposer.org/doc/03-cli.md#install-i) options to consider:
  - `--prefer-dist` - "This can speed up installs substantially on build servers and other use cases where you typically do not run updates of the vendors."
  - `--no-dev` - For JS, I have some makefiles that automatically trim dev deps. It reduces how much data ends up in Docker images, for one thing.
  - `--no-suggest` - Suggestions are pretty annoying.
  - `--optimize-autoloader` - "This is recommended especially for production, but can take a bit of time to run so it is currently not done by default."
  - `--ignore-platform-reqs` - I think we can do without this now.
- Some [`composer validate`](https://getcomposer.org/doc/03-cli.md#validate) options to consider:
  - `--strict` - "Return a non-zero exit code for warnings as well as errors."
  - `--no-check-publish` - Maybe sometimes we don't want this?

Other commands to be considered for new targets:
- [`composer outdated`](https://getcomposer.org/doc/03-cli.md#outdated) - Pretty useful, and similar things exist for NPM/Yarn. Composer's defaults are dumb because they show you outdated *transitive* dependencies, which is useless and takes forever. The `--direct` and `--strict` options are probably sane defaults.