### PR TITLE
Set better default options for composer validate

### DIFF
--- a/bin/composer-package-type
+++ b/bin/composer-package-type
@@ -1,0 +1,21 @@
+#!/usr/bin/env php
+<?php
+
+$composerJson = @file_get_contents('composer.json');
+
+if (false === $composerJson) {
+    exit(0);
+}
+
+$composer = json_decode($composerJson);
+
+if (JSON_ERROR_NONE !== json_last_error()) {
+    error_log('Unable to read composer.json');
+    exit(1);
+}
+
+if (property_exists($composer, 'type')) {
+    echo $composer->type . PHP_EOL;
+} else {
+    echo 'library' . PHP_EOL;
+}

--- a/composer.mk
+++ b/composer.mk
@@ -1,5 +1,24 @@
+# The type of package as defined in the composer.json "type" property
+COMPOSER_PACKAGE_TYPE := $(shell $(MF_ROOT)/pkg/php/v1/bin/composer-package-type)
+
+# Whether this package is intended to be published
+ifeq ($(COMPOSER_PACKAGE_TYPE),library)
+COMPOSER_PUBLISH ?= true
+else
+COMPOSER_PUBLISH ?=
+endif
+
+# COMPOSER_VALIDATE_PUBLISH_ARGS and COMPOSER_VALIDATE_NO_PUBLISH_ARGS are
+# arguments passed to "composer validate"
+COMPOSER_VALIDATE_PUBLISH_ARGS    ?= --strict
+COMPOSER_VALIDATE_NO_PUBLISH_ARGS ?= --no-check-publish
+
+################################################################################
+
 # Ensure that dependencies are installed before attempting to build a Docker image.
 DOCKER_BUILD_REQ += composer.json composer.lock
+
+################################################################################
 
 # prepare --- Perform tasks that need to be executed before committing. Stacks
 # with the "prepare" target form the common makefile.
@@ -18,7 +37,8 @@ composer.json:
 	composer init --no-interaction
 
 artifacts/composer/validate.touch: composer.json
-	composer validate --no-check-publish
+	$(eval ARGS := $(if $(COMPOSER_PUBLISH),$(COMPOSER_VALIDATE_PUBLISH_ARGS),$(COMPOSER_VALIDATE_NO_PUBLISH_ARGS)))
+	composer validate $(ARGS)
 
 	@mkdir -p "$(@D)"
 	@touch "$@"


### PR DESCRIPTION
Implementation notes:

- You can manually specify `COMPOSER_PUBLISH` in order to override the behavior
- The behavior of `composer validate` is pretty disappointing:
  - For published projects, `--strict` works well.
  - For non-published projects, `--no-check-publish --strict` will enforce that `license` is set, which doesn't make much sense to me.
  - If you omit `--strict` when using `--no-check-publish`, it will at least ignore the `license`, but it will actually show more "warnings" about missing `name` and `description` 🤷‍♂️
- I went with just `--no-check-publish` for non-published projects because besides the verbose warnings, it seems the least annoying.
- I verified that `composer validate` *does* indeed exit with a non-zero code if the lockfile needs updating, so that case should be covered by `make prepare`.

I'm still a bit shaky on my Makefile syntax. Could you make sure I'm using the right assignments etc.?