### PR TITLE
Implement a PHPUnit mixin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,6 @@
 # PHP_SOURCE_FILES is a space separated list of source files in the repo.
 PHP_SOURCE_FILES += $(shell PATH="$(PATH)" git-find '*.php')
 
-# PHP_TEST_INI_FILE is the path to a PHP INI file that should be used when
-# running tests.
-PHP_TEST_INI_FILE ?= $(shell PATH="$(PATH)" find-file test/php.ini)
-
-# PHP_TEST_ARGS is a set of arguments to pass to PHP when running tests.
-ifeq ($(PHP_TEST_INI_FILE),)
-PHP_TEST_ARGS +=
-else
-PHP_TEST_ARGS += -c "$(PHP_TEST_INI_FILE)"
-endif
-
 # PHP_PHPUNIT_CONFIG_FILE is the path to any existing PHPUnit XML configuration.
 PHP_PHPUNIT_CONFIG_FILE ?= $(shell PATH="$(PATH)" find-file phpunit.xml phpunit.xml.dist)
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,41 @@
+# Always run tests by default, even if other makefiles are included beforehand.
+.DEFAULT_GOAL := test
+
+# PHP_SOURCE_FILES is a space separated list of source files in the repo.
+PHP_SOURCE_FILES += $(shell PATH="$(PATH)" git-find '*.php')
+
+# PHP_TEST_INI_FILE is the path to a PHP INI file that should be used when
+# running tests.
+PHP_TEST_INI_FILE ?= $(shell PATH="$(PATH)" find-file test/php.ini)
+
+# PHP_TEST_ARGS is a set of arguments to pass to PHP when running tests.
+ifeq ($(PHP_TEST_INI_FILE),)
+PHP_TEST_ARGS +=
+else
+PHP_TEST_ARGS += -c "$(PHP_TEST_INI_FILE)"
+endif
+
+# PHP_PHPUNIT_CONFIG_FILE is the path to any existing PHPUnit XML configuration.
+PHP_PHPUNIT_CONFIG_FILE ?= $(shell PATH="$(PATH)" find-file phpunit.xml phpunit.xml.dist)
+
+################################################################################
+
+# _PHP_EXECUTABLES is a space separated list of all executable files in the bin
+# directory.
+_PHP_EXECUTABLES := $(shell find bin -type f -perm +111 2> /dev/null)
+
+# _PHP_TEST_ASSETS is a space separated list of all non-PHP files in the test
+# directory.
+_PHP_TEST_ASSETS := $(shell find test -type f -not -iname "*.php" 2> /dev/null)
+
 # Ensure that dependencies are installed before attempting to build a Docker
 # image.
 DOCKER_BUILD_REQ += vendor
 
+################################################################################
+
 -include .makefiles/pkg/php/v1/composer.mk
+
+ifneq ($(PHP_PHPUNIT_CONFIG_FILE),)
+-include .makefiles/pkg/php/v1/phpunit.mk
+endif

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,6 @@ PHP_PHPUNIT_CONFIG_FILE ?= $(shell PATH="$(PATH)" find-file phpunit.xml phpunit.
 
 ################################################################################
 
-# _PHP_EXECUTABLES is a space separated list of all executable files in the bin
-# directory.
-_PHP_EXECUTABLES := $(shell find bin -type f -perm +111 2> /dev/null)
-
 # _PHP_TEST_ASSETS is a space separated list of all non-PHP files in the test
 # directory.
 _PHP_TEST_ASSETS := $(shell find test -type f -not -iname "*.php" 2> /dev/null)

--- a/phpunit.mk
+++ b/phpunit.mk
@@ -1,13 +1,19 @@
 # PHP_PHPUNIT_REQ is a space separated list of prerequisites needed to run the
 # PHPUnit tests.
-PHP_PHPUNIT_REQ += $(PHP_PHPUNIT_CONFIG_FILE) $(PHP_SOURCE_FILES) $(_PHP_TEST_ASSETS)
+PHP_PHPUNIT_REQ +=
+
+################################################################################
+
+# _PHP_PHPUNIT_REQ is a space separated list of automatically detected
+# prerequisites needed to run the PHPUnit tests.
+_PHP_PHPUNIT_REQ += $(PHP_PHPUNIT_CONFIG_FILE) $(PHP_SOURCE_FILES) $(_PHP_TEST_ASSETS)
 
 ################################################################################
 
 # test --- Executes all PHPUnit tests in this package. Stacks with test targets
 # from other test runners.
 .PHONY: test
-test:: $(PHP_PHPUNIT_REQ) | vendor
+test:: $(PHP_PHPUNIT_REQ) $(_PHP_PHPUNIT_REQ) | vendor
 	php $(PHP_TEST_ARGS) vendor/bin/phpunit -c $(PHP_PHPUNIT_CONFIG_FILE) --no-coverage
 
 # coverage --- Produces an HTML coverage report. Stacks with coverage targets
@@ -33,8 +39,8 @@ ci:: artifacts/coverage/phpunit/clover.xml
 
 ################################################################################
 
-artifacts/coverage/phpunit/index.html: $(PHP_PHPUNIT_REQ) | vendor
+artifacts/coverage/phpunit/index.html: $(PHP_PHPUNIT_REQ) $(_PHP_PHPUNIT_REQ) | vendor
 	phpdbg $(PHP_TEST_ARGS) -qrr vendor/bin/phpunit -c $(PHP_PHPUNIT_CONFIG_FILE) --coverage-html="$(@D)"
 
-artifacts/coverage/phpunit/clover.xml: $(PHP_PHPUNIT_REQ) | vendor
+artifacts/coverage/phpunit/clover.xml: $(PHP_PHPUNIT_REQ) $(_PHP_PHPUNIT_REQ) | vendor
 	phpdbg $(PHP_TEST_ARGS) -qrr vendor/bin/phpunit -c $(PHP_PHPUNIT_CONFIG_FILE) --coverage-clover="$@"

--- a/phpunit.mk
+++ b/phpunit.mk
@@ -10,21 +10,33 @@ _PHP_PHPUNIT_REQ += $(PHP_PHPUNIT_CONFIG_FILE) $(PHP_SOURCE_FILES) $(_PHP_TEST_A
 
 ################################################################################
 
-# test --- Executes all PHPUnit tests in this package. Stacks with test targets
-# from other test runners.
+# test --- Executes all tests in this package. Stacks with test targets from
+# other test runners.
 .PHONY: test
-test:: $(PHP_PHPUNIT_REQ) $(_PHP_PHPUNIT_REQ) | vendor
-	php $(PHP_TEST_ARGS) vendor/bin/phpunit -c $(PHP_PHPUNIT_CONFIG_FILE) --no-coverage
+test:: test-phpunit
 
 # coverage --- Produces an HTML coverage report. Stacks with coverage targets
 # from other test runners.
 .PHONY: coverage
-coverage:: artifacts/coverage/phpunit/index.html
+coverage:: coverage-phpunit
 
-# coverage-open --- Opens the HTML coverage report in a browser. Stacks with
+# coverage-open --- Opens all HTML coverage reports in a browser. Stacks with
 # coverage-open targets from other test runners.
 .PHONY: coverage-open
-coverage-open:: artifacts/coverage/phpunit/index.html
+coverage-open:: coverage-phpunit-open
+
+# test-phpunit --- Executes all PHPUnit tests in this package.
+.PHONY: test-phpunit
+test-phpunit: $(PHP_PHPUNIT_REQ) $(_PHP_PHPUNIT_REQ) | vendor
+	php $(PHP_TEST_ARGS) vendor/bin/phpunit -c $(PHP_PHPUNIT_CONFIG_FILE) --no-coverage
+
+# coverage-phpunit --- Produces a PHPUnit HTML coverage report.
+.PHONY: coverage-phpunit
+coverage-phpunit: artifacts/coverage/phpunit/index.html
+
+# coverage-phpunit-open --- Opens the PHPUnit HTML coverage report in a browser.
+.PHONY: coverage-phpunit-open
+coverage-phpunit-open: artifacts/coverage/phpunit/index.html
 	open "$<"
 
 # prepare --- Perform tasks that need to be executed before committing. Stacks

--- a/phpunit.mk
+++ b/phpunit.mk
@@ -1,0 +1,40 @@
+# PHP_PHPUNIT_REQ is a space separated list of prerequisites needed to run the
+# PHPUnit tests.
+PHP_PHPUNIT_REQ += $(PHP_PHPUNIT_CONFIG_FILE) $(PHP_SOURCE_FILES) $(_PHP_EXECUTABLES) $(_PHP_TEST_ASSETS)
+
+################################################################################
+
+# test --- Executes all PHPUnit tests in this package. Stacks with test targets
+# from other test runners.
+.PHONY: test
+test:: $(PHP_PHPUNIT_REQ) | vendor
+	php $(PHP_TEST_ARGS) vendor/bin/phpunit -c $(PHP_PHPUNIT_CONFIG_FILE) --no-coverage
+
+# coverage --- Produces an HTML coverage report. Stacks with coverage targets
+# from other test runners.
+.PHONY: coverage
+coverage:: artifacts/coverage/phpunit/index.html
+
+# coverage-open --- Opens the HTML coverage report in a browser. Stacks with
+# coverage-open targets from other test runners.
+.PHONY: coverage-open
+coverage-open:: artifacts/coverage/phpunit/index.html
+	open "$<"
+
+# prepare --- Perform tasks that need to be executed before committing. Stacks
+# with the "prepare" target form the common makefile.
+.PHONY: prepare
+prepare:: test
+
+# ci --- Builds a machine-readable coverage report. Stacks with the "ci" target
+# from the common makefile.
+.PHONY: ci
+ci:: artifacts/coverage/phpunit/clover.xml
+
+################################################################################
+
+artifacts/coverage/phpunit/index.html: $(PHP_PHPUNIT_REQ) | vendor
+	phpdbg $(PHP_TEST_ARGS) -qrr vendor/bin/phpunit -c $(PHP_PHPUNIT_CONFIG_FILE) --coverage-html="$(@D)"
+
+artifacts/coverage/phpunit/clover.xml: $(PHP_PHPUNIT_REQ) | vendor
+	phpdbg $(PHP_TEST_ARGS) -qrr vendor/bin/phpunit -c $(PHP_PHPUNIT_CONFIG_FILE) --coverage-clover="$@"

--- a/phpunit.mk
+++ b/phpunit.mk
@@ -1,6 +1,6 @@
 # PHP_PHPUNIT_REQ is a space separated list of prerequisites needed to run the
 # PHPUnit tests.
-PHP_PHPUNIT_REQ += $(PHP_PHPUNIT_CONFIG_FILE) $(PHP_SOURCE_FILES) $(_PHP_EXECUTABLES) $(_PHP_TEST_ASSETS)
+PHP_PHPUNIT_REQ += $(PHP_PHPUNIT_CONFIG_FILE) $(PHP_SOURCE_FILES) $(_PHP_TEST_ASSETS)
 
 ################################################################################
 

--- a/phpunit.mk
+++ b/phpunit.mk
@@ -4,9 +4,21 @@ PHP_PHPUNIT_REQ +=
 
 ################################################################################
 
+# _PHP_PHPUNIT_INI_FILE is the path to a PHP INI file that should be used when
+# running PHPUnit tests.
+_PHP_PHPUNIT_INI_FILE ?= $(shell PATH="$(PATH)" find-file php.phpunit.ini)
+
 # _PHP_PHPUNIT_REQ is a space separated list of automatically detected
 # prerequisites needed to run the PHPUnit tests.
-_PHP_PHPUNIT_REQ += $(PHP_PHPUNIT_CONFIG_FILE) $(PHP_SOURCE_FILES) $(_PHP_TEST_ASSETS)
+_PHP_PHPUNIT_REQ += $(_PHP_PHPUNIT_INI_FILE) $(PHP_PHPUNIT_CONFIG_FILE) $(PHP_SOURCE_FILES) $(_PHP_TEST_ASSETS)
+
+# _PHP_PHPUNIT_RUNTIME_ARGS is a set of arguments to pass to the PHP runtime
+# when running PHPUnit tests.
+ifeq ($(_PHP_PHPUNIT_INI_FILE),)
+_PHP_PHPUNIT_RUNTIME_ARGS +=
+else
+_PHP_PHPUNIT_RUNTIME_ARGS += -c "$(_PHP_PHPUNIT_INI_FILE)"
+endif
 
 ################################################################################
 
@@ -28,7 +40,7 @@ coverage-open:: coverage-phpunit-open
 # test-phpunit --- Executes all PHPUnit tests in this package.
 .PHONY: test-phpunit
 test-phpunit: $(PHP_PHPUNIT_REQ) $(_PHP_PHPUNIT_REQ) | vendor
-	php $(PHP_TEST_ARGS) vendor/bin/phpunit -c $(PHP_PHPUNIT_CONFIG_FILE) --no-coverage
+	php $(_PHP_PHPUNIT_RUNTIME_ARGS) vendor/bin/phpunit -c $(PHP_PHPUNIT_CONFIG_FILE) --no-coverage
 
 # coverage-phpunit --- Produces a PHPUnit HTML coverage report.
 .PHONY: coverage-phpunit
@@ -52,7 +64,7 @@ ci:: artifacts/coverage/phpunit/clover.xml
 ################################################################################
 
 artifacts/coverage/phpunit/index.html: $(PHP_PHPUNIT_REQ) $(_PHP_PHPUNIT_REQ) | vendor
-	phpdbg $(PHP_TEST_ARGS) -qrr vendor/bin/phpunit -c $(PHP_PHPUNIT_CONFIG_FILE) --coverage-html="$(@D)"
+	phpdbg $(_PHP_PHPUNIT_RUNTIME_ARGS) -qrr vendor/bin/phpunit -c $(PHP_PHPUNIT_CONFIG_FILE) --coverage-html="$(@D)"
 
 artifacts/coverage/phpunit/clover.xml: $(PHP_PHPUNIT_REQ) $(_PHP_PHPUNIT_REQ) | vendor
-	phpdbg $(PHP_TEST_ARGS) -qrr vendor/bin/phpunit -c $(PHP_PHPUNIT_CONFIG_FILE) --coverage-clover="$@"
+	phpdbg $(_PHP_PHPUNIT_RUNTIME_ARGS) -qrr vendor/bin/phpunit -c $(PHP_PHPUNIT_CONFIG_FILE) --coverage-clover="$@"


### PR DESCRIPTION
This PR implements a mixin for PHPUnit support.

- A default goal of `test` is set in the main makefile. If no test runners are detected make will report `make: Nothing to be done for 'test'.`, which I think is clear enough.
- The PHPUnit config file is searched for at the same default locations as PHPUnit uses, and with the same precedence (`phpunit.xml`, `phpunit.xml.dist` \[sic\]). Can be overridden with `PHP_PHPUNIT_CONFIG_FILE`.
- An optional PHP INI file for running tests is supported at `test/php.ini`. The location differs from CWX makefiles (`test/etc/php.ini`), because it's more in line with the PHPUnit convention of configuration files in the root directory. It still needs to be in `test`, because the root directory might need its own `php.ini` for bundling into a Docker image, for example.
- Tests automatically depend on any `.php` files, as well as all files in the `test` directory. These are kept in `_PHP_PHPUNIT_REQ`. Users can add other deps to `PHP_PHPUNIT_REQ`.
- The `test`, `coverage`, and `coverage-open` targets have all been kept "stackable", allowing for repos that use multiple test runners. In addition, there are specific `test-phpunit`, `coverage-phpunit`, and `coverage-phpunit-open` targets, if users wish to only run the PHPUnit tests for performance reasons.