### PR TITLE
Implement a PHP CS Fixer mixin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@
 # PHP_SOURCE_FILES is a space separated list of source files in the repo.
 PHP_SOURCE_FILES += $(shell PATH="$(PATH)" git-find '*.php')
 
+# PHP_CS_FIXER_CONFIG_FILE is the path to any existing PHP CS Fixer
+# configuration.
+PHP_CS_FIXER_CONFIG_FILE ?= $(shell PATH="$(PATH)" find-first-matching-file .php_cs .php_cs.dist)
+
 # PHP_PERIDOT_CONFIG_FILE is the path to any existing Peridot configuration.
 PHP_PERIDOT_CONFIG_FILE ?= $(shell PATH="$(PATH)" find-first-matching-file peridot.php)
 
@@ -23,6 +27,10 @@ DOCKER_BUILD_REQ += vendor
 ################################################################################
 
 -include .makefiles/pkg/php/v1/composer.mk
+
+ifneq ($(PHP_CS_FIXER_CONFIG_FILE),)
+-include .makefiles/pkg/php/v1/php-cs-fixer.mk
+endif
 
 ifneq ($(PHP_PERIDOT_CONFIG_FILE),)
 -include .makefiles/pkg/php/v1/peridot.mk

--- a/php-cs-fixer.mk
+++ b/php-cs-fixer.mk
@@ -1,0 +1,54 @@
+# PHP_CS_FIXER_REQ is a space separated list of prerequisites needed to run PHP
+# CS Fixer.
+PHP_CS_FIXER_REQ +=
+
+################################################################################
+
+# _PHP_CS_FIXER_REQ is a space separated list of automatically detected
+# prerequisites needed to run PHP CS Fixer.
+_PHP_CS_FIXER_REQ += $(PHP_CS_FIXER_CONFIG_FILE) $(PHP_SOURCE_FILES)
+
+# _PHP_CS_FIXER_CACHE_FILE is a path to the cache file to use when running PHP
+# CS Fixer.
+_PHP_CS_FIXER_CACHE_FILE := artifacts/lint/php-cs-fixer/cache
+
+# _PHP_CS_FIXER_ARGS is a space separated list of arguments to pass to PHP CS
+# Fixer.
+_PHP_CS_FIXER_ARGS := fix --config "$(PHP_CS_FIXER_CONFIG_FILE)" --cache-file "$(_PHP_CS_FIXER_CACHE_FILE)"
+
+################################################################################
+
+# lint --- Check for code style and formatting issues, fixing automatically
+# where possible. Stacks with the "lint" target from other makefiles.
+.PHONY: lint
+lint:: lint-php-cs-fixer
+
+# prepare --- Perform tasks that need to be executed before committing. Stacks
+# with the "prepare" target from the common makefile.
+.PHONY: prepare
+prepare:: lint-php-cs-fixer
+
+# ci --- Enforce code style and formatting rules. Stacks with the "ci" target
+# from the common makefile.
+.PHONY: ci
+ci:: artifacts/lint/php-cs-fixer-ci.touch
+
+# lint-php-cs-fixer --- Check for PHP code style and formatting issues, fixing
+# automatically where possible.
+.PHONY: lint-php-cs-fixer
+lint-php-cs-fixer: artifacts/lint/php-cs-fixer-fix.touch
+
+################################################################################
+
+artifacts/lint/php-cs-fixer:
+	@mkdir -p "$@"
+
+artifacts/lint/php-cs-fixer-ci.touch: artifacts/lint/php-cs-fixer $(PHP_CS_FIXER_REQ) $(_PHP_CS_FIXER_REQ) | vendor
+	vendor/bin/php-cs-fixer $(_PHP_CS_FIXER_ARGS) --dry-run
+
+	@touch "$@"
+
+artifacts/lint/php-cs-fixer-fix.touch: artifacts/lint/php-cs-fixer $(PHP_CS_FIXER_REQ) $(_PHP_CS_FIXER_REQ) | vendor
+	vendor/bin/php-cs-fixer $(_PHP_CS_FIXER_ARGS)
+
+	@touch "$@"


### PR DESCRIPTION
- Pretty similar in approach to other mixins with regards to config file detection.
- The `php-cs-fixer` executable doesn't automatically create the parent directory of the cache file, so I created a separate target for the directory itself, which is also used for the `.touch` files. Let me know if there's anything wrong with this approach.
- <del>Variable names all start with `PHP_PHP_CS_FIXER_` which is kinda gross, but consistent.</del> Fixed