### PR TITLE
Add support for all major coverage drivers

### DIFF
--- a/bin/coverage-driver
+++ b/bin/coverage-driver
@@ -1,0 +1,50 @@
+#!/usr/bin/env php
+<?php
+
+$supported = ['pcov', 'xdebug', 'phpdbg'];
+$drivers = [];
+
+for ($i = 1; $i < $argc; ++$i) {
+    $driver = $argv[$i];
+
+    if (!in_array($driver, $supported, true)) {
+        error_log(sprintf('Unsupported coverage driver %s', $driver));
+        exit(1);
+    }
+
+    $drivers[] = $driver;
+}
+
+if (count($drivers) < 1) {
+    error_log('Usage: coverage-driver driver...');
+    error_log(sprintf('  each driver must be one of %s', implode(', ', $supported)));
+    exit(1);
+}
+
+foreach ($drivers as $driver) {
+    if ('pcov' === $driver) {
+        if (extension_loaded('pcov')) {
+            echo "pcov\n";
+            exit(0);
+        }
+
+        continue;
+    }
+
+    if ('xdebug' === $driver) {
+        if (extension_loaded('xdebug')) {
+            echo "xdebug\n";
+            exit(0);
+        }
+
+        continue;
+    }
+
+    if ('phpdbg' === $driver) {
+        echo "phpdbg\n";
+        exit(0);
+    }
+}
+
+error_log(sprintf('No suitable coverage driver detected (tried %s)', implode(', ', $drivers)));
+exit(1);

--- a/peridot.mk
+++ b/peridot.mk
@@ -15,6 +15,10 @@ _PHP_PERIDOT_REQ += vendor $(PHP_PERIDOT_CONFIG_FILE) $(PHP_SOURCE_FILES) $(_PHP
 # _PHP_PERIDOT_ARGS is a set of arguments to use for every execution of Peridot.
 _PHP_PERIDOT_ARGS := -c "$(PHP_PERIDOT_CONFIG_FILE)" --reporter "$(PHP_PERIDOT_PRIMARY_REPORTER)"
 
+# _PHP_PERIDOT_COVERAGE_DRIVER is the extension or SAPI that will be used for
+# Peridot code coverage generation.
+_PHP_PERIDOT_COVERAGE_DRIVER := $(shell $(MF_ROOT)/pkg/php/v1/bin/coverage-driver xdebug phpdbg)
+
 ################################################################################
 
 # test --- Executes all tests.
@@ -56,10 +60,18 @@ ci-peridot: artifacts/coverage/peridot/clover.xml
 ################################################################################
 
 artifacts/coverage/peridot/index.html: $(PHP_PERIDOT_REQ) $(_PHP_PERIDOT_REQ)
-	phpdbg -qrr vendor/bin/peridot $(_PHP_PERIDOT_ARGS) --reporter html-code-coverage --code-coverage-path "$(@D)"
+ifeq ($(_PHP_PERIDOT_COVERAGE_DRIVER),phpdbg)
+	phpdbg -d=pcov.enabled=0 -qrr vendor/bin/peridot $(_PHP_PERIDOT_ARGS) --reporter html-code-coverage --code-coverage-path "$(@D)"
+else
+	vendor/bin/peridot $(_PHP_PERIDOT_ARGS) --reporter html-code-coverage --code-coverage-path "$(@D)"
+endif
 
 artifacts/coverage/peridot/clover.xml: $(PHP_PERIDOT_REQ) $(_PHP_PERIDOT_REQ)
-	phpdbg -qrr vendor/bin/peridot $(_PHP_PERIDOT_ARGS) --reporter clover-code-coverage --code-coverage-path "$(@D)"
+ifeq ($(_PHP_PERIDOT_COVERAGE_DRIVER),phpdbg)
+	phpdbg -d=pcov.enabled=0 -qrr vendor/bin/peridot $(_PHP_PERIDOT_ARGS) --reporter clover-code-coverage --code-coverage-path "$(@D)"
+else
+	vendor/bin/peridot $(_PHP_PERIDOT_ARGS) --reporter clover-code-coverage --code-coverage-path "$(@D)"
+endif
 
 artifacts/test/peridot.touch: $(PHP_PERIDOT_REQ) $(_PHP_PERIDOT_REQ)
 	vendor/bin/peridot $(_PHP_PERIDOT_ARGS)


### PR DESCRIPTION
This PR adds support for PHP coverage drivers other than `phpdbg`.

- The `bin/coverage-driver` script will output the first available driver from the supplied list, or error if none are available.
- In general the order of preference will now become:
  1. `pcov` (if installed and supported by the test runner)
  2. `xdebug` (if installed)
  3. `phpdbg`
- PHPUnit is currently the only test runner that supports `pcov`. Kahlan and Peridot both support only `xdebug` or `phpdbg`.
- If `pcov` is installed, and `vendor/bin/pcov` is executable, then the coverage targets will run `vendor/bin/pcov clobber` before the test suite. This allows PCOV support for older versions of PHPUnit.
- At the moment, if pcov is enabled, `phpdbg` will segfault. This means that for test runners that don't support `pcov`, we must explicitly pass `-d=pcov.enabled=0` to `phpdbg`, because you might have `pcov` installed for your PHPUnit tests, but need `phpdbg` for your Kahlan tests in the same project.
- <del>If you have a custom INI file, it breaks the loading of extensions as per make-files/issues#22, meaning that coverage will fall back to `phpdbg`. I think this is a good enough reason to drop custom INI files completely.</del> - INI support has been removed